### PR TITLE
Support a custom entrypoint.

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+log(){ echo "$*" >&2; }
+
+set -- /config/docker/run "$@"
+
+if [ "$(id -u)" = "0" ]; then
+  PACKAGES="su-exec $PACKAGES"
+  log "Installing extra packages"
+  apk add --quiet --no-progress --no-cache $PACKAGES
+
+  USER="homeassistant"
+  PUID="${PUID:-1000}"
+  PGID="${PGID:-1000}"
+
+  # While su-exec works with a uid:gid input, some HA
+  # commands seem to fail if we don't have an actual
+  # user. ie: shell_command would return error code 255
+  log "Creating user $USER with $PUID:$PGID"
+  deluser "$USER" >/dev/null 2>&1
+  delgroup "$USER" >/dev/null 2>&1
+  addgroup -g "$PGID" "$USER"
+  adduser -G "$USER" -D -H -u "$PUID" "$USER"
+
+  log "Dropping privileges to $USER"
+  set -- su-exec "$USER:$USER" "$@"
+else
+  log "Not running as root. Extra packages won't be installed."
+fi
+
+# replace the current pid 1 with original command
+exec "$@"

--- a/run
+++ b/run
@@ -17,4 +17,6 @@ python3 -m venv --system-site-packages "$VENV"
 . "$VENV/bin/activate"
 
 log "Starting homeassistant"
-exec python3 -m homeassistant --config /config
+set -- ${@:-python3 -m homeassistant --config /config}
+# replace the current pid 1 with the original command
+exec "$@"


### PR DESCRIPTION
Contributing back some of my personal changes. Feel free to decline if this is not something you wish to maintain.

I had a need to install custom packages to my container because the busybox ping command cannot run as root. Both local fixes actually a root account before dropping privileges. To help me there I added a custom entrypoint script.

The entrypoint is totally optional. The old command/user technique still works. It works with docker's `user` as well so the doc could remove the command override section I guess. Though if extra actions must be performed before privileges are dropped it is necessary to start the container as root and pass in `PUID` and `PGID` as env. vars.

This entrypoint will make sure the final command runs as PID 1 so interrupts are passed down to HA. Another side benefit that I seem to have noticed (but it could be just me) is that the "Rerstart" button in HA actually works. It seemed to me that pressing it with the `user`/`command` settings would just do nothing.