### PR TITLE
Allow run 'ping' as non-root user

### DIFF
--- a/run
+++ b/run
@@ -50,6 +50,12 @@ if [ -n "${EXTRA_GID:-}" ]; then
 fi
 
 #
+# Allow run 'ping' as non-root user
+#
+
+chmod u+s /bin/ping
+
+#
 # Install extra packages
 #
 


### PR DESCRIPTION
There is a problem with alpine images that prevents executing 'ping' as non root user.