### PR TITLE
Install packages only once

### DIFF
--- a/run
+++ b/run
@@ -66,8 +66,12 @@ fi
 #
 
 if [ -n "${PACKAGES}" ]; then
-  bashio::log.info "Installing extra packages: $PACKAGES"
-  apk add --quiet --no-progress --no-cache -- $PACKAGES
+  for package in $PACKAGES; do
+    if ! apk -e info "$package"; then # check if already installed
+      bashio::log.info "Installing extra package: $package"
+      apk add --quiet --no-progress --no-cache -- "$package"
+    fi
+  done
 fi
 
 #


### PR DESCRIPTION
This PR fixes Home Assistant starting without Internet connection when $PACKAGES is defined for second and next runs. We don't need to update package(s) without container updating anyway. It should be a more generic way to solve https://github.com/tribut/homeassistant-docker-venv/pull/8.