### PR TITLE
Fix run script for Home Assistant 2024.10+

### DIFF
--- a/run
+++ b/run
@@ -101,6 +101,7 @@ fi
 bashio::log.info "Activating venv"
 # shellcheck source=/dev/null
 . "$VENV_PATH/bin/activate"
+export UV_SYSTEM_PYTHON=false
 
 bashio::log.info "Setting new \$HOME"
 HOME="$( getent passwd "$USER" | cut -d: -f6 )"


### PR DESCRIPTION
Fixes #36.

Home Assistant moved to `uv` in 2024.10. And they set `UV_SYSTEM_PYTHON=true` in their Docker image. This causes several errors during start up when extra packages are installed (for example, by HACS), because the flag makes `uv` ignore the venv and work on system python packages instead.

We fix this by setting `UV_SYSTEM_PYTHON=false` after creating a venv.