### PR TITLE
Several improvements

### DIFF
--- a/run
+++ b/run
@@ -7,6 +7,10 @@ PUID="${PUID:-1000}"
 PGID="${PGID:-1000}"
 HASS_OPTIONS="${HASS_OPTIONS:-}"
 
+S6_READ_ONLY_ROOT="${S6_READ_ONLY_ROOT:-0}"
+if [ "$S6_READ_ONLY_ROOT" -eq 1 ] ; then
+   bashio::log.warning "Cannot perform user/group/package manipulation: Read-only file system"
+fi
 
 UMASK="${UMASK:-}"
 
@@ -33,7 +37,7 @@ delgroup "$GROUP" >/dev/null 2>&1 || true
 # Re-use existing group (can't delgroup a group that is in use)
 group="$(getent group "$PGID" | cut -d: -f1 || true)"
 if [ -z "$group" ]; then
-  addgroup -g "$PGID" "$GROUP"
+  addgroup -g "$PGID" "$GROUP" 2>/dev/null || ( [ "$S6_READ_ONLY_ROOT" -eq 0 ] && bashio::exit.nok "Cannot add group $GROUP/$PGID" ) || [ "$S6_READ_ONLY_ROOT" -eq 1 ] ;
 else
   bashio::log.notice "Re-using existing group with gid $PGID: $group"
   GROUP="$group"
@@ -43,9 +47,9 @@ fi
 user="$(getent passwd "$PUID" | cut -d: -f1 || true)"
 if [ -n "$user" ]; then
   bashio::log.notice "Replacing existing user with uid $PUID: $user"
-  deluser "$user"
+  deluser "$user" 2>/dev/null || ( [ "$S6_READ_ONLY_ROOT" -eq 0 ] && bashio::exit.nok "Cannot delete $user" ) || [ "$S6_READ_ONLY_ROOT" -eq 1 ];
 fi
-adduser -G "$GROUP" -D -u "$PUID" "$USER"
+adduser -G "$GROUP" -D -u "$PUID" "$USER" 2>/dev/null || ( [ "$S6_READ_ONLY_ROOT" -eq 0 ] && bashio::exit.nok "Cannot add user $USER/$PUID" ) || [ "$S6_READ_ONLY_ROOT" -eq 1 ];
 
 if [ -n "${EXTRA_GID:-}" ]; then
   bashio::log.info "Resolving supplementary GIDs: $EXTRA_GID"
@@ -56,7 +60,7 @@ if [ -n "${EXTRA_GID:-}" ]; then
 
     if [ -z "$group" ]; then
       group="$USER-$gid"
-      addgroup -g "$gid" "$group"
+      addgroup -g "$gid" "$group" 2>/dev/null || ( [ "$S6_READ_ONLY_ROOT" -eq 0 ] && bashio::exit.nok "Cannot add supplementary $group/$gid" ) || [ "$S6_READ_ONLY_ROOT" -eq 1 ];
     fi
 
     supplementary_groups+=( "$group" )
@@ -64,7 +68,7 @@ if [ -n "${EXTRA_GID:-}" ]; then
 
   bashio::log.info "Appending supplementary groups: ${supplementary_groups[*]}"
   for group in "${supplementary_groups[@]}"; do
-    addgroup "$USER" "$group"
+    addgroup "$USER" "$group" 2>/dev/null || ( [ "$S6_READ_ONLY_ROOT" -eq 0 ] && bashio::exit.nok "Cannot add user $USER to supplementary group $group" ) || [ "$S6_READ_ONLY_ROOT" -eq 1 ];
   done
 fi
 
@@ -75,7 +79,7 @@ fi
 for package in $REQUIRED_PACKAGES $PACKAGES; do
   if ! apk info --quiet --installed -- "$package"; then
     bashio::log.info "Installing package: $package"
-    apk add --quiet --no-progress --no-cache -- "$package"
+    apk add --quiet --no-progress --no-cache -- "$package" || ( [ "$S6_READ_ONLY_ROOT" -eq 0 ] && bashio::exit.nok "Cannot install package $package" ) || [ "$S6_READ_ONLY_ROOT" -eq 1 ];
   fi
 done
 
@@ -83,9 +87,9 @@ done
 # Create virtual environment
 #
 
-bashio::log.info "Initializing venv in $VENV_PATH"
-su "$USER" \
-  -c "python3 -m venv --system-site-packages '$VENV_PATH'"
+bashio::log.info "Initializing venv in $VENV_PATH for user $USER/$PUID and group $GROUP/$PGID"
+s6-applyuidgid -u $PUID -g $PGID \
+  python3 "-m" "venv" "--system-site-packages" "$VENV_PATH"
 
 #
 # Fix permissions
@@ -106,17 +110,16 @@ bashio::log.info "Activating venv"
 export UV_SYSTEM_PYTHON=false
 
 bashio::log.info "Installing uv into venv"
-uv --version && su "$USER" \
-  -c "uv pip freeze --system|grep ^uv=|xargs uv pip install"
+uv --version && s6-applyuidgid -u $PUID -g $PGID \
+  uv pip freeze --system|grep ^uv=|xargs uv pip install
 
 bashio::log.info "Setting new \$HOME"
-HOME="$( getent passwd "$USER" | cut -d: -f6 )"
+HOME="$( getent passwd "$USER" || echo ":::::/home/$USER" | cut -d: -f6 )"
 export HOME
 bashio::log.info "New HOME: $HOME"
 
-chown -R "${USER}":"${GROUP}" /config
-
-bashio::log.info "Extra options: $HASS_OPTIONS"
+bashio::log.info "Changing file ownership in $CONFIG_PATH to $PUID:$PGID"
+chown -R "${PUID}":"${PGID}" "$CONFIG_PATH"
 
 # Everything below should be kept in sync with upstream's
 #   https://github.com/home-assistant/core/blob/dev/rootfs/etc/services.d/home-assistant/run
@@ -128,7 +131,7 @@ if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then
   export MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000"
 fi
 
-bashio::log.info "Starting homeassistant"
+bashio::log.info "Starting homeassistant, extra options: ${HASS_OPTIONS:-None}"
 exec \
-  s6-setuidgid "$USER" \
-  python3 -m homeassistant --config "$CONFIG_PATH" $HASS_OPTIONS
+  s6-applyuidgid -u $PUID -g $PGID -G ${EXTRA_GID:-PGID} \
+    python3 -m homeassistant --config "$CONFIG_PATH" $HASS_OPTIONS

--- a/run
+++ b/run
@@ -1,10 +1,12 @@
 #!/usr/bin/with-contenv bashio
 # shellcheck shell=bash
 
-USER="homeassistant"
+USER="${USER:-homeassistant}"
 GROUP="$USER"
 PUID="${PUID:-1000}"
 PGID="${PGID:-1000}"
+HASS_OPTIONS="${HASS_OPTIONS:-}"
+
 
 UMASK="${UMASK:-}"
 
@@ -110,6 +112,11 @@ uv --version && su "$USER" \
 bashio::log.info "Setting new \$HOME"
 HOME="$( getent passwd "$USER" | cut -d: -f6 )"
 export HOME
+bashio::log.info "New HOME: $HOME"
+
+chown -R "${USER}":"${GROUP}" /config
+
+bashio::log.info "Extra options: $HASS_OPTIONS"
 
 # Everything below should be kept in sync with upstream's
 #   https://github.com/home-assistant/core/blob/dev/rootfs/etc/services.d/home-assistant/run
@@ -124,4 +131,4 @@ fi
 bashio::log.info "Starting homeassistant"
 exec \
   s6-setuidgid "$USER" \
-  python3 -m homeassistant --config "$CONFIG_PATH"
+  python3 -m homeassistant --config "$CONFIG_PATH" $HASS_OPTIONS

--- a/run
+++ b/run
@@ -112,6 +112,8 @@ export UV_SYSTEM_PYTHON=false
 bashio::log.info "Installing uv into venv"
 uv --version && s6-applyuidgid -u $PUID -g $PGID \
   uv pip freeze --system|grep ^uv=|xargs uv pip install
+rm -rf /tmp/* || true
+chown -R "${PUID}":"${PGID}" "$VENV_PATH"
 
 bashio::log.info "Setting new \$HOME"
 HOME="$( getent passwd "$USER" || echo ":::::/home/$USER" | cut -d: -f6 )"


### PR DESCRIPTION
    1. Added possibility to specify the user name, instead of default homeassistant
    2. Added possibility to pass extra options to HASS
    3. Added chown to the user:group before dropping root capabilities

    HASS still complaints about followinf issue, do not know how to fix it. Tried many ways playing with caps, all fail.
    Missing required permissions for Bluetooth management: Missing NET_ADMIN/NET_RAW capabilities for Bluetooth management.
    Automatic adapter recovery is unavailable. Add NET_ADMIN and NET_RAW capabilities to the container to enable it

    Sample docker-compose file:

    services:
      hass:
        container_name: homeassistant
        image: "ghcr.io/home-assistant/home-assistant:stable"
        restart: unless-stopped
        stop_grace_period: 30s

        volumes:
          - /home/hass/hass:/config:rw
          - /home/hass/tmp/docker/run:/etc/services.d/home-assistant/run:ro 
          - /home/hass/tmp/hass-venv:/var/tmp/homeassistant-venv:rw 
          - /etc/localtime:/etc/localtime:ro 
          - /run/dbus:/run/dbus:ro 
         tmpfs: 
          - /tmp:rw,noexec,nosuid,size=64m

        privileged: true
        security_opt:
          - no-new-privileges=true
          - apparmor=docker-default 
         cap_drop: 
           - ALL 
          cap_add: 
            - NET_ADMIN 
            - NET_RAW

        network_mode: host

        group_add:
          - dialout  # Dialout group

        environment:
          - TZ=Europe/Amsterdam
          - USER=hass 
          - PUID=1004 
          - PGID=1004 
          - UMASK=007 
          - PACKAGES=iputils 
          - HASS_OPTIONS=${HASS_OPTIONS} 
          - UV_LINK_MODE=copy 
          - PIP_CACHE_DIR=/var/tmp/homeassistant-venv/.pip-cache
   